### PR TITLE
404 Not Found serving .woff2

### DIFF
--- a/Source/MvcBoilerplate/Content/bootstrap/site.less
+++ b/Source/MvcBoilerplate/Content/bootstrap/site.less
@@ -5,4 +5,4 @@
 
 @import "bootstrap.less";
 
-@icon-font-path:        "../../Content/fonts/bootstrap";
+@icon-font-path:        "../../Content/fonts/bootstrap/";

--- a/Source/MvcBoilerplate/Web.config
+++ b/Source/MvcBoilerplate/Web.config
@@ -276,6 +276,9 @@
       <!-- .woff - Served as font/woff. Use the correct MIME type of application/x-font-woff. -->
       <remove fileExtension=".woff" />
       <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" />
+      <!-- .woff2 - Served as font/woff. Use the correct MIME type of application/x-font-woff. -->
+      <remove fileExtension=".woff2" />
+      <mimeMap fileExtension=".woff2" mimeType="application/x-font-woff" />
       <!-- .webp - IIS does not have a WEBP MIME type by default. -->
       <remove fileExtension=".webp" />
       <mimeMap fileExtension=".webp" mimeType="image/webp" />

--- a/Source/MvcBoilerplateTemplate/Content/bootstrap/site.less
+++ b/Source/MvcBoilerplateTemplate/Content/bootstrap/site.less
@@ -5,4 +5,4 @@
 
 @import "bootstrap.less";
 
-@icon-font-path:        "../../Content/fonts/bootstrap";
+@icon-font-path:        "../../Content/fonts/bootstrap/";

--- a/Source/MvcBoilerplateTemplate/Web.config
+++ b/Source/MvcBoilerplateTemplate/Web.config
@@ -276,6 +276,9 @@
       <!-- .woff - Served as font/woff. Use the correct MIME type of application/x-font-woff. -->
       <remove fileExtension=".woff" />
       <mimeMap fileExtension=".woff" mimeType="application/x-font-woff" />
+      <!-- .woff2 - Served as font/woff. Use the correct MIME type of application/x-font-woff. -->
+      <remove fileExtension=".woff2" />
+      <mimeMap fileExtension=".woff2" mimeType="application/x-font-woff" />
       <!-- .webp - IIS does not have a WEBP MIME type by default. -->
       <remove fileExtension=".webp" />
       <mimeMap fileExtension=".webp" mimeType="image/webp" />


### PR DESCRIPTION
Add mimeMap to fix "404 not found" error when serving "ghyphicon-halflings-regular.woff2".
Fixed bootstrap glyphicon "404 not found" error. Path missing "/" on bootstrap "site.less".