### PR TITLE
Matching the style with VS MVC Template

### DIFF
--- a/Source/MvcBoilerplate/Content/Site.less
+++ b/Source/MvcBoilerplate/Content/Site.less
@@ -1,4 +1,4 @@
-﻿body {
+body {
     padding-top: 50px;
     padding-bottom: 20px;
 }
@@ -12,4 +12,11 @@
 /* Allow only vertical resizing of textareas. */
 textarea {
     resize: vertical;
+}
+
+/* Set width on the form input elements since they're 100% wide by default */
+input,
+select,
+textarea {
+    max-width: 280px;
 }


### PR DESCRIPTION
Set width on the form input elements since they're 100% wide by default