### PR TITLE
Change padding-top to 70px for Bootstrap fixed-top navbar

### DIFF
--- a/Source/MVC5/Boilerplate.Web.Mvc5.Sample/Content/Site.css
+++ b/Source/MVC5/Boilerplate.Web.Mvc5.Sample/Content/Site.css
@@ -1,5 +1,5 @@
 ﻿body {
-  padding-top: 50px;
+  padding-top: 70px;
   padding-bottom: 20px;
 }
 /* Set padding to keep content from hitting the edges. */

--- a/Source/MVC5/Boilerplate.Web.Mvc5.Sample/Content/Site.less
+++ b/Source/MVC5/Boilerplate.Web.Mvc5.Sample/Content/Site.less
@@ -1,5 +1,5 @@
 ﻿body {
-    padding-top: 50px;
+    padding-top: 70px;
     padding-bottom: 20px;
 }
 

--- a/Source/MVC6/Boilerplate.Web.Mvc6.Sample/Styles/site.scss
+++ b/Source/MVC6/Boilerplate.Web.Mvc6.Sample/Styles/site.scss
@@ -1,7 +1,7 @@
 ﻿@import '../bower_components/bootstrap-sass/assets/stylesheets/_bootstrap.scss';
 
 body {
-    padding-top: 50px;
+    padding-top: 70px;
     padding-bottom: 20px;
 }
 


### PR DESCRIPTION
Even Microsft ships ASP.NET MVC default template use 50px
for padding-top of body, but in Bootstrap document has stated that
for fixed-top navbar it should use 70px instead.

Closed #33