### PR TITLE
Updated the tagHelper to the new package name

### DIFF
--- a/Source/MVC6/Boilerplate.AspNetCore.Sample/Views/_ViewImports.cshtml
+++ b/Source/MVC6/Boilerplate.AspNetCore.Sample/Views/_ViewImports.cshtml
@@ -12,4 +12,4 @@
 @using Microsoft.AspNetCore.Http
 @using Microsoft.Extensions.Options
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
-@addTagHelper *, Boilerplate.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Boilerplate.AspNetCore.TagHelpers


### PR DESCRIPTION
Subject says it all. Prevents following error:

Cannot resolve TagHelper containing assembly 'Boilerplate.AspNetCore.Mvc.TagHelpers'. Error: Could not load file or assembly 'Boilerplate.AspNetCore.Mvc.TagHelpers, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.
@addTagHelper *, Boilerplate.AspNetCore.Mvc.TagHelpers